### PR TITLE
fix: ignore non-header lines before turbostat's real header

### DIFF
--- a/internal/parser.go
+++ b/internal/parser.go
@@ -130,6 +130,21 @@ func (p *TurbostatParser) ParseRows(inputRows [][]string) ([]TurbostatRow, error
 	return rows, nil
 }
 
+// isTurbostatHeaderLine checks whether fields look like a genuine turbostat
+// header row. Every turbostat header starts with "Package", "Core", or "CPU"
+// depending on the system topology (see SetupColumnParsers).
+func isTurbostatHeaderLine(fields []string) bool {
+	if len(fields) == 0 {
+		return false
+	}
+	switch fields[0] {
+	case "Package", "Core", "CPU":
+		return true
+	default:
+		return false
+	}
+}
+
 func sanitizeHeader(h string) string {
 	res := strings.ReplaceAll(h, "%", "")
 	res = strings.ToLower(res)
@@ -341,8 +356,15 @@ func ParseTurbostatOutput(raw string) ([]string, [][]string, error) {
 			continue
 		}
 
-		// If headers not set, use this line as headers
+		// If headers not set, use this line as headers - but only if it actually
+		// looks like a turbostat header. turbostat prints warnings (e.g. about
+		// insufficient privileges to access /dev/cpu/*/msr) on the same stream
+		// before the real header line, and those must not be mistaken for it.
 		if len(headers) == 0 {
+			if !isTurbostatHeaderLine(fields) {
+				log.Warn().Msgf("Ignoring unexpected line before turbostat header: %s", line)
+				continue
+			}
 			headers = fields
 			continue
 		}

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -119,6 +119,36 @@ func TestParseRows_SingleRow(t *testing.T) {
 	}
 }
 
+// Reproduces https://github.com/BlackDark/prometheus_turbostat_exporter/issues/11
+// When turbostat lacks sufficient privileges (e.g. no root/CAP_SYS_RAWIO), it prints
+// a warning sentence on stdout/stderr before the real header line. main.go merges
+// stdout+stderr, so that sentence must not be mistaken for the turbostat header.
+func TestParseOutput_PrivilegeWarningBeforeHeader(t *testing.T) {
+	headers, rows, err := ParseTurbostatOutput(`Some of the counters may not be available to access /dev/cpu/0/msr.
+Core	CPU	Avg_MHz	Busy%
+-	-	125	6.57
+0	0	80	9.91
+`)
+
+	if err != nil {
+		t.Fatalf("expected parsing turbostat output to succeed, got error: %v", err)
+	}
+
+	wantHeaders := []string{"Core", "CPU", "Avg_MHz", "Busy%"}
+	if len(headers) != len(wantHeaders) {
+		t.Fatalf("expected headers %v, got %v", wantHeaders, headers)
+	}
+	for i, h := range wantHeaders {
+		if headers[i] != h {
+			t.Errorf("expected header[%d] = %q, got %q", i, h, headers[i])
+		}
+	}
+
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 data rows, got %d: %v", len(rows), rows)
+	}
+}
+
 func TestParseOutput_RealWithSeconds(t *testing.T) {
 	headers, rows, err := ParseTurbostatOutput(`0.007923 sec
 Core CPU Test


### PR DESCRIPTION
## Summary
- Fixes #11 — running turbostat without sufficient privileges printed a warning about `/dev/cpu/*/msr` access on the same stream as its data (main.go merges stdout+stderr), and the parser blindly used the first non-empty line as the header. Words from that warning (`some`, `of`, `access`, ...) ended up as metric `type` labels, with real counter values shifted onto them.
- `ParseTurbostatOutput` now only accepts a line as the header if it starts with `Package`, `Core`, or `CPU` — the shape every genuine turbostat header has. Anything else before the real header is logged and skipped.

## Test plan
- [x] Added `TestParseOutput_PrivilegeWarningBeforeHeader`, which fails on `main` (header wrongly becomes the warning sentence) and passes with this fix.
- [x] `go test ./...` passes, including existing `sandy-bridge.tsv` / `prox.tsv` fixture tests.