### PR TITLE
chore: golangci-lint, zizmor hardening, Dockerfile hardening, Helm chart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.claude
+docs
+dashboards
+data
+helm
+*.md
+.env
+.env.*
+docker-compose.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,22 @@ permissions:
   contents: write
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: go.sum
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,45 +5,54 @@ on:
   pull_request: # Trigger on pull requests
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26"
           cache-dependency-path: go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.12.2
 
   build:
     runs-on: ubuntu-latest
+    # contents: write is only needed here (not workflow-wide) so the Release
+    # step below can attach binaries to a GitHub Release on tag pushes.
+    permissions:
+      contents: write
     strategy:
       matrix:
         goos: [linux]
         goarch: [amd64, arm64]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v5
+        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
         with:
           short-length: 8 # Same as v3 and before
 
-      - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26"
           cache-dependency-path: go.sum
+          cache: false
       # You can test your matrix by printing the current Go version
       - name: Display Go version
         run: go version
@@ -51,7 +60,7 @@ jobs:
         run: go get .
       - name: Build
         run: |
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-X 'main.Version=${{ env.GITHUB_REF_SLUG }}'" -o turbostat-exporter-${{ matrix.goos }}-${{ matrix.goarch }}
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-X 'main.Version=${GITHUB_REF_SLUG}'" -o turbostat-exporter-${{ matrix.goos }}-${{ matrix.goarch }}
           chmod +x turbostat-exporter-${{ matrix.goos }}-${{ matrix.goarch }}
       # - name: Archive binaries
       #   uses: actions/upload-artifact@v4
@@ -60,7 +69,7 @@ jobs:
       #     path: turbostat-exporter-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: github.event_name == 'pull_request' # Conditionally upload on PRs
         with:
           name: turbostat-exporter-${{ matrix.goos }}-${{ matrix.goarch }}
@@ -68,8 +77,17 @@ jobs:
           retention-days: 7 # Specify retention period
 
       - name: Release
-        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            turbostat-exporter-*
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/}"
+          # Matrix jobs run in parallel: whichever job's `release create` wins
+          # creates the release with its own binary attached; the other job's
+          # `create` fails because the release now exists, so it falls back to
+          # uploading its binary into the release the first job just made.
+          if ! gh release create "$tag" --generate-notes turbostat-exporter-*; then
+            gh release upload "$tag" turbostat-exporter-* --clobber
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,10 @@ jobs:
           retention-days: 7 # Specify retention period
 
       - name: Release
-        if: startsWith(github.ref, 'refs/tags/')
+        # Match only the app's v*.*.* tags, not helm-vX.Y.Z chart-release
+        # tags (see .github/workflows/helm.yml) - both would otherwise
+        # race to create/attach to a GitHub Release with the same tag name.
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,30 +19,32 @@ jobs:
     steps:
       # Get the repositery's code
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v5
+        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
         with:
           short-length: 8 # Same as v3 and before
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
         with:
           image: tonistiigi/binfmt:qemu-v8.1.5 # more recent
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       #      - name: Available platforms
       #        run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -55,7 +57,7 @@ jobs:
       #     password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Docker meta for PMS
         id: meta_pms
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -68,7 +70,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - name: Build and push PMS
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,78 @@
+name: Helm Chart Release
+
+on:
+  push:
+    tags:
+      - "helm-v*.*.*"
+
+permissions:
+  contents: read
+
+env:
+  CHART_PATH: helm/turbostat-exporter
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v4.2.2
+
+      - name: Determine version from tag
+        id: version
+        run: |
+          set -euo pipefail
+          echo "version=${GITHUB_REF_NAME#helm-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Chart.yaml version matches the tag
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          chart_version="$(helm show chart "$CHART_PATH" | awk -F': ' '/^version:/ {print $2}')"
+          if [ "$chart_version" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Chart.yaml version ($chart_version) does not match tag $GITHUB_REF_NAME (expected $EXPECTED_VERSION). Bump Chart.yaml's version and retag."
+            exit 1
+          fi
+
+      - name: Lint chart
+        run: helm lint "$CHART_PATH"
+
+      - name: Package chart
+        run: helm package "$CHART_PATH" -d dist
+
+      - name: Log in to GHCR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_ACTOR: ${{ github.actor }}
+        run: helm registry login ghcr.io --username "$GH_ACTOR" --password-stdin <<< "$GH_TOKEN"
+
+      - name: Push chart to GHCR
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          owner_lower="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          helm push "dist/turbostat-exporter-${VERSION}.tgz" "oci://ghcr.io/${owner_lower}/charts"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Helm chart v${VERSION}" \
+            --generate-notes \
+            "dist/turbostat-exporter-${VERSION}.tgz"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: Zizmor
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # required so the SARIF results can be uploaded to the Security tab
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.env
 !.env.template
 .DS_Store
-turbostat-exporter
+/turbostat-exporter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - copyloopvar
+    - durationcheck
+    - errorlint
+    - gocritic
+    - gosec
+    - misspell
+    - nilerr
+    - predeclared
+    - revive
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - whitespace
+  settings:
+    gosec:
+      excludes:
+        # G204: subprocess launched with variable - the turbostat command is
+        # built from a fixed template plus a validated integer, not user input.
+        - G204
+  exclusions:
+    presets:
+      - comments
+      - std-error-handling
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.4 AS build
+FROM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS build
 WORKDIR /app
 ARG BUILD_VERSION=dev
 
@@ -16,11 +16,17 @@ COPY internal/ internal/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'main.Version=${BUILD_VERSION}'" -o /turbostat-exporter
 
-FROM debian:sid-slim
+# sid (unstable) is used deliberately: stable/testing ship a linux-cpupower
+# package with an older turbostat that doesn't recognize newer CPU
+# generations. This trades reproducible package versions for turbostat
+# currency; the base image itself is still pinned by digest below.
+FROM debian:sid-slim@sha256:02aca65ed93bc0a93e4cd1f04cda43bee12daf09283ddff0fe8d03713c16e966
 
 RUN <<EOF
-    apt update
-    apt install -y linux-cpupower 
+    set -eu
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends linux-cpupower
+    apt-get clean
     rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,32 @@ You can download the binaries for available platforms in the [Releases](https://
 
 - Run with `turbostat-exporter`. Default listener on `0.0.0.0:9101` (also displayed as logs),
 - or run with docker (but must be run as priviliged to have all information available):
-  `docker run -p 9101:9101 --privileged ghcr.io/blackdark/prometheus_turbostat_exporter:main`
+  `docker run -p 9101:9101 --privileged ghcr.io/blackdark/prometheus_turbostat_exporter:main`
+- or deploy to Kubernetes with the [Helm chart](./helm/turbostat-exporter) (see below).
 
+## Kubernetes / Helm
+
+A Helm chart is available at [`helm/turbostat-exporter`](./helm/turbostat-exporter),
+published as an OCI artifact:
+
+```bash
+helm install turbostat-exporter oci://ghcr.io/blackdark/charts/turbostat-exporter --version <chart-version>
+```
+
+It deploys turbostat-exporter as a **DaemonSet** (one pod per node, since
+turbostat reads host hardware counters rather than per-container state).
+
+Unlike the plain-Docker instructions above, the chart does **not** use
+`--privileged`. turbostat needs to read `/dev/cpu/*/msr`, which on a stock
+kernel is `root:root` mode `0600`, and the kernel's msr driver additionally
+requires the `CAP_SYS_RAWIO` capability regardless of UID - so by default the
+chart runs the container as root with only `SYS_RAWIO`/`SYS_ADMIN` added to
+an otherwise fully-dropped capability set (`privileged: false`,
+`readOnlyRootFilesystem: true`, seccomp `RuntimeDefault`). It also creates
+**no Kubernetes RBAC** (no Role/ClusterRole) - the app never talks to the
+Kubernetes API. See the [chart README](./helm/turbostat-exporter/README.md#why-this-chart-needs-elevated-permissions)
+for the full rationale and for how to reduce this further if your hosts
+already restrict msr access differently.
 
 ## Example scrape output
 
@@ -77,6 +101,9 @@ The application can be configured using environment variables defined in a `.env
 - `TURBOSTAT_EXPORTER_DEBUG_CAT_EXEC`: If set to `true`, uses a test mode with sample data.
 - `TURBOSTAT_COLLECT_IN_BACKGROUND`: Enables background data collection if set to `true`.
 - `TURBOSTAT_COLLECT_IN_BACKGROUND_INTERVAL`: Interval for background data collection.
+- `TURBOSTAT_LISTEN_ADDR`: Address/port the HTTP server listens on (default `0.0.0.0:9101`).
+- `TURBOSTAT_BASIC_AUTH_ENABLED`: Enable HTTP basic auth on `/metrics` if set to `true`.
+- `TURBOSTAT_BASIC_AUTH_USERNAME` / `TURBOSTAT_BASIC_AUTH_PASSWORD`: Required when basic auth is enabled.
 
 ## Development
 
@@ -84,6 +111,37 @@ To modify the code:
 
 1. **Edit source files** in your preferred editor.
 2. **Rebuild the application** using the build command above.
+
+CI runs [golangci-lint](https://golangci-lint.run/) (config in `.golangci.yml`)
+and [zizmor](https://docs.zizmor.sh/) (GitHub Actions workflow security
+scanning) on every push and pull request. Run them locally with:
+
+```bash
+golangci-lint run ./...
+zizmor .github/workflows/
+```
+
+## Releasing
+
+Two independent things can be released from this repository:
+
+- **The application**: push a tag matching `v*.*.*` (e.g. `v1.2.3`). This
+  triggers `.github/workflows/build.yml` (binaries attached to a GitHub
+  Release) and `.github/workflows/docker.yml` (multi-tag image pushed to
+  `ghcr.io/blackdark/prometheus_turbostat_exporter`).
+- **The Helm chart**: bump `version` in
+  [`helm/turbostat-exporter/Chart.yaml`](./helm/turbostat-exporter/Chart.yaml),
+  then push a tag matching `helm-vX.Y.Z` matching that version (e.g. bump to
+  `0.2.0` and tag `helm-v0.2.0`). This triggers
+  `.github/workflows/helm.yml`, which refuses to run if the tag and
+  `Chart.yaml` version don't match, then packages the chart, pushes it to
+  `oci://ghcr.io/blackdark/charts/turbostat-exporter`, and attaches the
+  packaged `.tgz` to a GitHub Release.
+
+The chart's version is intentionally independent from the application's
+version (see `appVersion` in `Chart.yaml`, which just documents the exporter
+version the chart defaults to) - a chart-only fix doesn't force an
+application release, and vice versa.
 
 ## Dependencies
 

--- a/docs/superpowers/specs/2026-07-05-helm-chart-and-release-design.md
+++ b/docs/superpowers/specs/2026-07-05-helm-chart-and-release-design.md
@@ -1,0 +1,101 @@
+# Helm Chart & Release Design
+
+Date: 2026-07-05
+Status: Approved
+
+## Context
+
+`prometheus_turbostat_exporter` reads host hardware counters (MSRs) via
+`turbostat`. Today the only supported container deployment is
+`docker run --privileged`. This design adds a Helm chart for Kubernetes with
+the minimum permissions that still work out of the box, plus a release
+pipeline for the chart, as one part of a larger PR that also adds
+golangci-lint, zizmor, and Dockerfile hardening.
+
+## Deployment shape
+
+- **DaemonSet**, one pod per node — turbostat measures host hardware state,
+  so it must run once per physical/VM host, not scale with application
+  replicas.
+- `hostNetwork: false`. Metrics are exposed via a `ClusterIP` `Service`.
+- An optional, disabled-by-default `ServiceMonitor` (prometheus-operator CRD)
+  is included for clusters that use it; a plain `Service` with scrape
+  annotations works without it.
+- No `hostPID`. The app never inspects host processes.
+- A `ServiceAccount` is created only to explicitly set
+  `automountServiceAccountToken: false`. No `Role`/`ClusterRole` is created —
+  the app never calls the Kubernetes API, so it needs zero Kubernetes RBAC
+  permissions. This is called out explicitly in the README so it's clear the
+  "permissions" this chart deals with are host/Linux capabilities, not
+  Kubernetes RBAC.
+
+## Host access / security context
+
+MSR access is gated two ways on stock kernels: the device file
+`/dev/cpu/*/msr` is normally `0600 root:root` (a DAC check), and the kernel's
+msr driver additionally requires `CAP_SYS_RAWIO` on open regardless of UID.
+turbostat's own error message when this fails suggests exactly these two
+fixes: "try chown or chmod +r /dev/cpu/*/msr, or run as root."
+
+Chart default, chosen to work unmodified on a stock kernel while dropping as
+much as possible from today's `--privileged`:
+
+- hostPath volume mounting `/dev/cpu` (type `Directory`), mounted read-only
+  in the container.
+- `securityContext`:
+  - `privileged: false`
+  - `runAsUser: 0` (required unless the host admin has chmod'd/chowned the
+    msr device — see README)
+  - `allowPrivilegeEscalation: false`
+  - `readOnlyRootFilesystem: true`
+  - `seccompProfile: { type: RuntimeDefault }`
+  - `capabilities: { drop: [ALL], add: [SYS_RAWIO, SYS_ADMIN] }`
+
+The README documents each capability's purpose, why root is still needed by
+default, and how a host admin can go further (chmod the device / udev rule)
+to eventually drop `runAsUser: 0` too — that path is not the chart default
+because it requires a manual host-side prerequisite that would otherwise
+silently break the chart on unmodified hosts.
+
+## Values
+
+- `image.repository` / `image.tag` (defaults to `.Chart.AppVersion`) /
+  `image.pullPolicy`
+- Env vars mirroring `configuration.go`: log level, default/background
+  collect intervals, background mode toggle, basic auth (`enabled`,
+  `username`, inline `password` or `existingSecret`/`existingSecretKey`)
+- `resources`, `nodeSelector`, `tolerations`, `affinity`
+- `service.type` / `service.port`
+- `serviceMonitor.enabled` (default `false`) plus standard
+  interval/labels/relabelings passthrough
+
+## Versioning & release pipeline
+
+The chart's `Chart.yaml` version is **independent** of the app's version
+(starts at `0.1.0`), bumped only when chart templates/values change.
+`appVersion` documents the exporter version the chart defaults to, updated
+manually when convenient — it is not auto-synced.
+
+A new GitHub Actions workflow (`.github/workflows/helm.yml`) triggers on
+tags matching `helm-v*.*.*`:
+
+1. Checkout, install `helm`.
+2. `helm lint` the chart.
+3. Package the chart (version taken from the tag).
+4. `helm push` the packaged chart as an OCI artifact to
+   `oci://ghcr.io/<owner>/charts/turbostat-exporter`.
+5. Create a GitHub Release for the tag with the packaged `.tgz` attached.
+
+This reuses the existing tag-triggered release pattern (`v*.*.*` already
+triggers `docker.yml`) with a distinct prefix so chart and app releases never
+collide. Cutting a chart release is: bump `Chart.yaml` version, tag
+`helm-vX.Y.Z`, push the tag — no manual workflow dispatch inputs, no
+Chart.yaml diffing logic in CI.
+
+## Out of scope
+
+- Publishing to a traditional Helm repo index (GitHub Pages + chart-releaser)
+  — OCI is now the standard distribution mechanism and avoids maintaining a
+  second branch/index.
+- Automatically bumping `appVersion` when the app releases — left as a
+  manual edit to keep the two release cadences fully decoupled.

--- a/helm/turbostat-exporter/.helmignore
+++ b/helm/turbostat-exporter/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/turbostat-exporter/Chart.yaml
+++ b/helm/turbostat-exporter/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: turbostat-exporter
+description: Prometheus exporter for turbostat CPU/core hardware metrics, deployed as a DaemonSet.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+home: https://github.com/BlackDark/prometheus_turbostat_exporter
+sources:
+  - https://github.com/BlackDark/prometheus_turbostat_exporter
+keywords:
+  - prometheus
+  - exporter
+  - turbostat
+  - cpu
+maintainers:
+  - name: BlackDark
+    url: https://github.com/BlackDark

--- a/helm/turbostat-exporter/README.md
+++ b/helm/turbostat-exporter/README.md
@@ -1,0 +1,80 @@
+# turbostat-exporter
+
+Helm chart for [prometheus_turbostat_exporter](https://github.com/BlackDark/prometheus_turbostat_exporter),
+deployed as a DaemonSet since turbostat reads host hardware counters and
+therefore only makes sense running once per node.
+
+## Install
+
+```bash
+helm install turbostat-exporter oci://ghcr.io/blackdark/charts/turbostat-exporter --version <chart-version>
+```
+
+## Why this chart needs elevated permissions
+
+turbostat reads CPU model-specific registers (MSRs) through
+`/dev/cpu/*/msr`. On a stock kernel that device file is `root:root` mode
+`0600`, and the kernel's msr driver *additionally* requires the
+`CAP_SYS_RAWIO` capability to open it at all, regardless of UID. This is
+also why the plain-Docker instructions in the main README use
+`docker run --privileged`.
+
+This chart does **not** use `privileged: true`. Instead its default
+`securityContext` is the narrowest configuration that still works
+unmodified on a stock kernel:
+
+| Setting | Value | Why |
+|---|---|---|
+| `runAsUser` | `0` | The msr device is owned `root:root`; a non-root UID gets `EACCES` at the filesystem permission check before the capability check is even reached. |
+| `capabilities.drop` | `[ALL]` | Start from nothing. |
+| `capabilities.add` | `[SYS_RAWIO, SYS_ADMIN]` | `SYS_RAWIO` is what the msr driver itself checks for. `SYS_ADMIN` is needed for some of turbostat's other hardware queries (varies by CPU generation). |
+| `privileged` | `false` | Everything else (seccomp, AppArmor, the rest of the capability set, device access beyond the one hostPath below) stays locked down. |
+| `readOnlyRootFilesystem` | `true` | The app writes nothing to disk. |
+| `allowPrivilegeEscalation` | `false` | Not needed once the above capabilities are granted directly. |
+
+It also mounts the node's `/dev/cpu` directory read-only into the
+container (`msrHostPath`, default `/dev/cpu`) — there is no way to expose
+specific host hardware devices to a container other than a hostPath mount.
+
+**Kubernetes RBAC is a separate concern from the above.** This chart
+creates a `ServiceAccount` only to set `automountServiceAccountToken: false`
+on it; it does **not** create any `Role`, `ClusterRole`, or binding, because
+the exporter never calls the Kubernetes API.
+
+### Going further: fully non-root
+
+If your hosts have already loosened access to the msr device (e.g. a udev
+rule that `chmod`s `/dev/cpu/*/msr` to be group- or world-readable, or
+`chown`s it to a non-root user/group), you can override:
+
+```yaml
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+```
+
+This is not the chart default because, on an unmodified host, it silently
+fails (`permission denied` reading every MSR) rather than falling back —
+turbostat's own error message when this happens is "try chown or chmod +r
+/dev/cpu/*/msr, or run as root."
+
+## Values
+
+See [values.yaml](./values.yaml) for the full list. Notable ones:
+
+- `image.tag` — defaults to `.Chart.AppVersion`. Override to pin an exact
+  exporter version or track `main`.
+- `background.enabled` / `background.intervalSeconds` /
+  `defaultCollectSeconds` — how often and how long turbostat samples for.
+- `basicAuth.*` — enable HTTP basic auth on `/metrics`. Use
+  `basicAuth.existingSecret` in anything beyond local testing rather than
+  the inline `basicAuth.password` value.
+- `serviceMonitor.enabled` — set `true` if you run prometheus-operator.
+- `msrHostPath` — override if your MSR devices live somewhere other than
+  `/dev/cpu` (unusual).
+
+## Releases
+
+This chart is versioned independently from the exporter application. See
+the repository root README's "Releasing" section for how chart releases
+are cut and published.

--- a/helm/turbostat-exporter/templates/NOTES.txt
+++ b/helm/turbostat-exporter/templates/NOTES.txt
@@ -1,0 +1,23 @@
+turbostat-exporter is deployed as a DaemonSet and should now be running on
+every node in the cluster (subject to any nodeSelector/tolerations/affinity
+you configured).
+
+Metrics are available at:
+
+  http://{{ include "turbostat-exporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics
+
+To check pods on each node:
+
+  kubectl get pods -n {{ .Release.Namespace }} -l "{{ include "turbostat-exporter.selectorLabels" . | replace "\n" "," }}" -o wide
+
+{{- if not .Values.serviceMonitor.enabled }}
+
+serviceMonitor.enabled is false. If you use prometheus-operator, set
+serviceMonitor.enabled=true to have it scraped automatically. Otherwise,
+point your Prometheus scrape config at the Service above.
+{{- end }}
+
+This chart runs the container as root with only the SYS_RAWIO/SYS_ADMIN
+Linux capabilities (not --privileged) because turbostat needs to read
+/dev/cpu/*/msr on the host. See the chart README for details and for how to
+reduce this further if your hosts allow it.

--- a/helm/turbostat-exporter/templates/_helpers.tpl
+++ b/helm/turbostat-exporter/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Chart name, truncated for use in resource names.
+*/}}
+{{- define "turbostat-exporter.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "turbostat-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "turbostat-exporter.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{ include "turbostat-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "turbostat-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "turbostat-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "turbostat-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "turbostat-exporter.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Secret name holding the basic-auth password.
+*/}}
+{{- define "turbostat-exporter.basicAuthSecretName" -}}
+{{- if .Values.basicAuth.existingSecret -}}
+{{- .Values.basicAuth.existingSecret -}}
+{{- else -}}
+{{- include "turbostat-exporter.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Secret key holding the basic-auth password.
+*/}}
+{{- define "turbostat-exporter.basicAuthSecretKey" -}}
+{{- if .Values.basicAuth.existingSecret -}}
+{{- .Values.basicAuth.existingSecretKey -}}
+{{- else -}}
+password
+{{- end -}}
+{{- end -}}

--- a/helm/turbostat-exporter/templates/daemonset.yaml
+++ b/helm/turbostat-exporter/templates/daemonset.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "turbostat-exporter.fullname" . }}
+  labels:
+    {{- include "turbostat-exporter.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "turbostat-exporter.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "turbostat-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "turbostat-exporter.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: turbostat-exporter
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          env:
+            - name: TURBOSTAT_LISTEN_ADDR
+              value: "0.0.0.0:{{ .Values.containerPort }}"
+            - name: TURBOSTAT_EXPORTER_LOG_LEVEL
+              value: {{ .Values.logLevel | quote }}
+            - name: TURBOSTAT_EXPORTER_DEFAULT_COLLECT_SECONDS
+              value: {{ .Values.defaultCollectSeconds | quote }}
+            - name: TURBOSTAT_COLLECT_IN_BACKGROUND
+              value: {{ .Values.background.enabled | quote }}
+            - name: TURBOSTAT_COLLECT_IN_BACKGROUND_INTERVAL
+              value: {{ .Values.background.intervalSeconds | quote }}
+            - name: TURBOSTAT_BASIC_AUTH_ENABLED
+              value: {{ .Values.basicAuth.enabled | quote }}
+            {{- if .Values.basicAuth.enabled }}
+            - name: TURBOSTAT_BASIC_AUTH_USERNAME
+              value: {{ .Values.basicAuth.username | quote }}
+            - name: TURBOSTAT_BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "turbostat-exporter.basicAuthSecretName" . }}
+                  key: {{ include "turbostat-exporter.basicAuthSecretKey" . }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: msr
+              mountPath: /dev/cpu
+              readOnly: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: msr
+          hostPath:
+            path: {{ .Values.msrHostPath }}
+            type: Directory
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/turbostat-exporter/templates/secret.yaml
+++ b/helm/turbostat-exporter/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.basicAuth.enabled (not .Values.basicAuth.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "turbostat-exporter.fullname" . }}
+  labels:
+    {{- include "turbostat-exporter.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ required "basicAuth.password is required when basicAuth.enabled is true and basicAuth.existingSecret is not set" .Values.basicAuth.password | quote }}
+{{- end -}}

--- a/helm/turbostat-exporter/templates/service.yaml
+++ b/helm/turbostat-exporter/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "turbostat-exporter.fullname" . }}
+  labels:
+    {{- include "turbostat-exporter.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: metrics
+      port: {{ .Values.service.port }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "turbostat-exporter.selectorLabels" . | nindent 4 }}

--- a/helm/turbostat-exporter/templates/serviceaccount.yaml
+++ b/helm/turbostat-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "turbostat-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "turbostat-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# Intentionally no Role/ClusterRole/RoleBinding: turbostat-exporter never
+# calls the Kubernetes API, so this ServiceAccount exists only so
+# automountServiceAccountToken can be disabled on the pod below.
+{{- end -}}

--- a/helm/turbostat-exporter/templates/servicemonitor.yaml
+++ b/helm/turbostat-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "turbostat-exporter.fullname" . }}
+  labels:
+    {{- include "turbostat-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "turbostat-exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/helm/turbostat-exporter/values.yaml
+++ b/helm/turbostat-exporter/values.yaml
@@ -1,0 +1,98 @@
+# Default values for turbostat-exporter.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/blackdark/prometheus_turbostat_exporter
+  # Defaults to .Chart.AppVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Port turbostat-exporter listens on, and the Service's target port.
+containerPort: 9101
+
+# -- TURBOSTAT_EXPORTER_LOG_LEVEL
+logLevel: info
+
+# -- TURBOSTAT_EXPORTER_DEFAULT_COLLECT_SECONDS: how long turbostat samples
+# for, either on each /metrics request (background.enabled: false) or before
+# each background tick (background.enabled: true).
+defaultCollectSeconds: 5
+
+background:
+  # -- TURBOSTAT_COLLECT_IN_BACKGROUND
+  enabled: true
+  # -- TURBOSTAT_COLLECT_IN_BACKGROUND_INTERVAL
+  intervalSeconds: 60
+
+basicAuth:
+  # -- TURBOSTAT_BASIC_AUTH_ENABLED
+  enabled: false
+  username: ""
+  # Plaintext password, stored in a Secret this chart creates. Prefer
+  # existingSecret for anything beyond local testing.
+  password: ""
+  # -- Name of an existing Secret to read the password from instead of
+  # basicAuth.password. Must contain the key named by existingSecretKey.
+  existingSecret: ""
+  existingSecretKey: password
+
+# -- Extra environment variables appended to the container, e.g. for
+# TURBOSTAT_EXPORTER_DEBUG_CAT_EXEC during testing.
+extraEnv: []
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+updateStrategy:
+  type: RollingUpdate
+
+podAnnotations: {}
+podLabels: {}
+
+# hostPath on the node that provides the MSR device files turbostat reads.
+msrHostPath: /dev/cpu
+
+# See README.md for why these are the defaults: turbostat needs to read
+# /dev/cpu/*/msr, which is root:root 0600 on stock kernels, and the kernel's
+# msr driver additionally requires CAP_SYS_RAWIO to open it regardless of
+# UID. This is already a large reduction from the `docker run --privileged`
+# used for plain Docker deployments.
+securityContext:
+  privileged: false
+  runAsUser: 0
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop: ["ALL"]
+    add: ["SYS_RAWIO", "SYS_ADMIN"]
+
+serviceAccount:
+  # -- This chart's ServiceAccount is never granted any Role/ClusterRole -
+  # the app never calls the Kubernetes API. It exists only so
+  # automountServiceAccountToken can be explicitly disabled.
+  create: true
+  name: ""
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 9101
+  annotations: {}
+
+# Requires the prometheus-operator CRDs installed in the cluster.
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: ""
+  labels: {}
+  relabelings: []
+  metricRelabelings: []

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -17,9 +17,9 @@ type TurbostatExporter struct {
 
 func NewTurbostatExporter() *TurbostatExporter {
 	labelsTotal := []string{"type"}
-	labelsPackage := append(labelsTotal, "package")
-	labelsCore := append(labelsPackage, "core")
-	labelsCpu := append(labelsCore, "cpu")
+	labelsPackage := []string{"type", "package"}
+	labelsCore := []string{"type", "package", "core"}
+	labelsCPU := []string{"type", "package", "core", "cpu"}
 
 	exporter := &TurbostatExporter{
 		packages: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -40,7 +40,7 @@ func NewTurbostatExporter() *TurbostatExporter {
 		}, labelsCore),
 		cpusPercent: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "turbostat_cpus_percent",
-		}, labelsCpu),
+		}, labelsCPU),
 		totalPercent: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "turbostat_total_percent",
 			Help: "Metrics for the whole system in percentages. First line in output.",
@@ -100,10 +100,10 @@ func (e *TurbostatExporter) Update(rows []TurbostatRow) {
 			}
 		case "cpu":
 			for t, v := range row.Other {
-				e.cpus.With(prometheus.Labels{"package": row.Pkg, "core": row.Core, "cpu": row.Cpu, "type": sanitizeHeader(t)}).Set(v)
+				e.cpus.With(prometheus.Labels{"package": row.Pkg, "core": row.Core, "cpu": row.CPU, "type": sanitizeHeader(t)}).Set(v)
 			}
 			for t, v := range row.OtherPercent {
-				e.cpusPercent.With(prometheus.Labels{"package": row.Pkg, "core": row.Core, "cpu": row.Cpu, "type": sanitizeHeader(t)}).Set(v)
+				e.cpusPercent.With(prometheus.Labels{"package": row.Pkg, "core": row.Core, "cpu": row.CPU, "type": sanitizeHeader(t)}).Set(v)
 			}
 		case "total":
 			for t, v := range row.Other {

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -45,7 +45,7 @@ func (p *TurbostatParser) SetupColumnParsers(headers []string) {
 	}
 
 	if headers[col] == "CPU" {
-		parsers = append(parsers, func(r *TurbostatRow, c string) { r.Cpu = c })
+		parsers = append(parsers, func(r *TurbostatRow, c string) { r.CPU = c })
 		col++
 	}
 
@@ -54,11 +54,11 @@ func (p *TurbostatParser) SetupColumnParsers(headers []string) {
 	}
 
 	for ; col < len(headers) && headers[col] != "POLL%"; col++ {
-		parsers = append(parsers, p.createColumnParser(func(r *TurbostatRow) map[string]float64 { return r.CpuStates }, headers[col]))
+		parsers = append(parsers, p.createColumnParser(func(r *TurbostatRow) map[string]float64 { return r.CPUStates }, headers[col]))
 	}
 
 	for ; col < len(headers) && !strings.HasPrefix(headers[col], "CPU"); col++ {
-		parsers = append(parsers, p.createColumnParser(func(r *TurbostatRow) map[string]float64 { return r.CpuStatesPercent }, headers[col]))
+		parsers = append(parsers, p.createColumnParser(func(r *TurbostatRow) map[string]float64 { return r.CPUStatesPercent }, headers[col]))
 	}
 
 	for ; col < len(headers) && !strings.HasPrefix(headers[col], "Core"); col++ {
@@ -100,9 +100,8 @@ func (p *TurbostatParser) createColumnParser(mapper func(r *TurbostatRow) map[st
 func (p *TurbostatParser) createDefaultColumnParser(header string) columnParseFunc {
 	if strings.Contains(header, "%") {
 		return p.createColumnParser(func(r *TurbostatRow) map[string]float64 { return r.OtherPercent }, header)
-	} else {
-		return p.createColumnParser(func(r *TurbostatRow) map[string]float64 { return r.Other }, header)
 	}
+	return p.createColumnParser(func(r *TurbostatRow) map[string]float64 { return r.Other }, header)
 }
 
 func (p *TurbostatParser) ParseRow(rowData []string) (*TurbostatRow, error) {
@@ -242,11 +241,11 @@ func (p *TurbostatParser) ParseRowSimple(category string, headers []string, row 
 		if headers[0] == "Package" {
 			tr.Pkg = row[0]
 			tr.Core = row[1]
-			tr.Cpu = row[2]
+			tr.CPU = row[2]
 			col = 3
 		} else {
 			tr.Core = row[0]
-			tr.Cpu = row[1]
+			tr.CPU = row[1]
 			col = 2
 		}
 	}

--- a/internal/row.go
+++ b/internal/row.go
@@ -5,10 +5,10 @@ import "maps"
 type TurbostatRow struct {
 	Pkg               string
 	Core              string
-	Cpu               string
+	CPU               string
 	CoreStatesPercent map[string]float64
-	CpuStates         map[string]float64
-	CpuStatesPercent  map[string]float64
+	CPUStates         map[string]float64
+	CPUStatesPercent  map[string]float64
 	Other             map[string]float64
 	OtherPercent      map[string]float64
 	PkgStatesPercent  map[string]float64
@@ -19,8 +19,8 @@ func NewTurbostatRow() *TurbostatRow {
 	return &TurbostatRow{
 		Pkg:               "0",
 		CoreStatesPercent: map[string]float64{},
-		CpuStates:         map[string]float64{},
-		CpuStatesPercent:  map[string]float64{},
+		CPUStates:         map[string]float64{},
+		CPUStatesPercent:  map[string]float64{},
 		Other:             map[string]float64{},
 		OtherPercent:      map[string]float64{},
 		PkgStatesPercent:  map[string]float64{},
@@ -34,18 +34,18 @@ func (r *TurbostatRow) CloneWithCategory(category string) *TurbostatRow {
 	clone := &TurbostatRow{
 		Pkg:               r.Pkg,
 		Core:              r.Core,
-		Cpu:               r.Cpu,
+		CPU:               r.CPU,
 		CoreStatesPercent: make(map[string]float64, len(r.CoreStatesPercent)),
-		CpuStates:         make(map[string]float64, len(r.CpuStates)),
-		CpuStatesPercent:  make(map[string]float64, len(r.CpuStatesPercent)),
+		CPUStates:         make(map[string]float64, len(r.CPUStates)),
+		CPUStatesPercent:  make(map[string]float64, len(r.CPUStatesPercent)),
 		Other:             make(map[string]float64, len(r.Other)),
 		OtherPercent:      make(map[string]float64, len(r.OtherPercent)),
 		PkgStatesPercent:  make(map[string]float64, len(r.PkgStatesPercent)),
 		Category:          category,
 	}
 	maps.Copy(clone.CoreStatesPercent, r.CoreStatesPercent)
-	maps.Copy(clone.CpuStates, r.CpuStates)
-	maps.Copy(clone.CpuStatesPercent, r.CpuStatesPercent)
+	maps.Copy(clone.CPUStates, r.CPUStates)
+	maps.Copy(clone.CPUStatesPercent, r.CPUStatesPercent)
 	maps.Copy(clone.Other, r.Other)
 	maps.Copy(clone.OtherPercent, r.OtherPercent)
 	maps.Copy(clone.PkgStatesPercent, r.PkgStatesPercent)

--- a/main.go
+++ b/main.go
@@ -165,7 +165,11 @@ func executeProgram(collectTimeSeconds int) (string, error) {
 
 func parseConfiguration() {
 	if err := godotenv.Load(); err != nil {
-		log.Debug().Msg("No .env file found, relying on process environment")
+		if os.IsNotExist(err) {
+			log.Debug().Msg("No .env file found, relying on process environment")
+		} else {
+			log.Warn().Err(err).Msg("Failed to load .env file, relying on process environment")
+		}
 	}
 
 	if val, ok := os.LookupEnv("TURBOSTAT_EXPORTER_LOG_LEVEL"); ok {

--- a/main.go
+++ b/main.go
@@ -19,15 +19,15 @@ import (
 )
 
 var (
-	Version                                = "development"
-	defaultSleepTimer        time.Duration = 5 * time.Second
-	isCommandCat                           = false
-	isBackgroundMode                       = true
-	backgroundCollectSeconds time.Duration = 60 * time.Second
-	basicAuthUsername        string
-	basicAuthPassword        string
-	basicAuthEnabled         = false
-	listenAddr               = "0.0.0.0:9101"
+	Version                   = "development"
+	defaultSleepTimer         = 5 * time.Second
+	isCommandCat              = false
+	isBackgroundMode          = true
+	backgroundCollectInterval = 60 * time.Second
+	basicAuthUsername         string
+	basicAuthPassword         string
+	basicAuthEnabled          = false
+	listenAddr                = "0.0.0.0:9101"
 )
 
 func main() {
@@ -94,7 +94,7 @@ func startServer(ctx context.Context, updateFunc func(time.Duration)) {
 
 	if isBackgroundMode {
 		log.Debug().Msgf("Starting ticker")
-		ticker := time.NewTicker(backgroundCollectSeconds)
+		ticker := time.NewTicker(backgroundCollectInterval)
 
 		go func() {
 			updateFunc(defaultSleepTimer)
@@ -125,7 +125,15 @@ func startServer(ctx context.Context, updateFunc func(time.Duration)) {
 
 	http.Handle("/metrics", metricsHandler)
 	log.Info().Msgf("Starting server on %s", listenAddr)
-	log.Fatal().Err(http.ListenAndServe(listenAddr, nil)).Msg("")
+	server := &http.Server{
+		Addr:              listenAddr,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		// In non-background mode each request runs turbostat synchronously for
+		// defaultSleepTimer, so the write deadline must cover that plus overhead.
+		WriteTimeout: defaultSleepTimer + 30*time.Second,
+	}
+	log.Fatal().Err(server.ListenAndServe()).Msg("")
 }
 
 func executeProgram(collectTimeSeconds int) (string, error) {
@@ -156,7 +164,9 @@ func executeProgram(collectTimeSeconds int) (string, error) {
 }
 
 func parseConfiguration() {
-	godotenv.Load()
+	if err := godotenv.Load(); err != nil {
+		log.Debug().Msg("No .env file found, relying on process environment")
+	}
 
 	if val, ok := os.LookupEnv("TURBOSTAT_EXPORTER_LOG_LEVEL"); ok {
 		level, err := zerolog.ParseLevel(val)
@@ -196,14 +206,14 @@ func parseConfiguration() {
 
 	if val, ok := os.LookupEnv("TURBOSTAT_COLLECT_IN_BACKGROUND_INTERVAL"); ok {
 		if convertVal, err := strconv.Atoi(val); err == nil && convertVal > 0 {
-			backgroundCollectSeconds = time.Duration(convertVal) * time.Second
+			backgroundCollectInterval = time.Duration(convertVal) * time.Second
 		} else {
-			log.Warn().Msgf("TURBOSTAT_COLLECT_IN_BACKGROUND_INTERVAL must be a positive integer. Using default: %s", backgroundCollectSeconds)
+			log.Warn().Msgf("TURBOSTAT_COLLECT_IN_BACKGROUND_INTERVAL must be a positive integer. Using default: %s", backgroundCollectInterval)
 		}
 	}
 
 	if isBackgroundMode {
-		log.Info().Msgf("Running collector in background with interval %s.", backgroundCollectSeconds)
+		log.Info().Msgf("Running collector in background with interval %s.", backgroundCollectInterval)
 	} else {
 		log.Info().Msgf("Running collector in active mode (on request will execute turbostat)")
 	}


### PR DESCRIPTION
## Summary

Four bundled efforts, each its own commit(s):

- **golangci-lint** (`.golangci.yml`, v2 schema, standard set + bodyclose/gocritic/gosec/revive/etc.). Fixed every finding: `Cpu`→`CPU` naming, an append-aliasing bug in `internal/exporter.go`, missing `http.Server` timeouts (gosec G114), unchecked `godotenv.Load()` error, redundant type annotations. Added a `lint` job to `build.yml`.
- **zizmor**: fixed all 17 high-severity findings across `build.yml`/`docker.yml` (unpinned actions → pinned to SHA with Renovate-friendly `# vX` comments, workflow-level `contents: write` scoped down to just the job that needs it, a template-injection risk in the ldflags build, `persist-credentials: false`, cache-poisoning mitigation) plus one informational one (replaced `softprops/action-gh-release` with `gh release create`/`gh release upload`). Added `.github/workflows/zizmor.yml` to keep auditing this on every push/PR.
- **Dockerfile hardening**: both base images pinned by digest, `apt` → `apt-get --no-install-recommends`, added `.dockerignore`. Verified the image still builds and runs.
- **Helm chart** (`helm/turbostat-exporter/`): DaemonSet with a `securityContext` that replaces `--privileged` with the minimum that still works on a stock kernel (root + `SYS_RAWIO`/`SYS_ADMIN` only, everything else dropped/locked down) — rationale documented in the chart README. No Kubernetes RBAC created (app never calls the k8s API). New `.github/workflows/helm.yml` publishes it as an OCI artifact on `helm-vX.Y.Z` tags, independent from the app's own `v*.*.*` release tags.

A design doc for the Helm chart + release strategy is at `docs/superpowers/specs/2026-07-05-helm-chart-and-release-design.md`.

Two independent review passes (fresh subagents, not just self-review) went through the whole diff adversarially. The first caught a real bug: `build.yml`'s Release step matched *any* tag, so it would have raced with `helm.yml` to create/attach to a GitHub Release under a `helm-vX.Y.Z` tag. Fixed in the last commit by scoping it to `refs/tags/v*`. The second pass verified that fix and swept for any other app/chart release collision — found none.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` all clean
- [x] `actionlint` and `zizmor .github/workflows/` both clean on all 4 workflow files
- [x] `docker build --platform linux/amd64 .` succeeds; binary + `turbostat --version` both work inside the built image
- [x] `helm lint`, `helm template` (default values, basicAuth inline password, basicAuth existingSecret, serviceMonitor.enabled, and the `required` guard when basicAuth is enabled with no password) all render correctly; rendered manifests pass `kubectl apply --dry-run=client`
- [x] `helm install --dry-run` succeeds end to end
- [ ] Actual `helm-vX.Y.Z` tag push and OCI push to `ghcr.io` — needs real registry credentials this environment doesn't have, so `helm.yml`'s push/release steps are logic-verified but not executed end-to-end